### PR TITLE
Pick correct route id from multiple results

### DIFF
--- a/nopeusbotti/bot.py
+++ b/nopeusbotti/bot.py
@@ -143,7 +143,10 @@ class Bot:
         result = client.execute(query)
 
         try:
-            route_id = result["routes"][0]["gtfsId"].replace("HSL:", "")
+            for r in result["routes"]:
+                if r["gtfsId"].endswith(route_number):
+                    route_id = r["gtfsId"].replace("HSL:", "")
+                    break
         except (KeyError, IndexError, AttributeError):
             raise ValueError("No valid ID found for route {route}")
 


### PR DESCRIPTION
I had issues with some shorter route numbers like "23" (route id _1023_) which got mixed with "239" (route id _2239_) due to their order in results.